### PR TITLE
#29 - 카테고리 / 태그 조회 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,16 @@ dependencies {
     implementation 'mysql:mysql-connector-java:8.0.27'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-    // swagger dependency
-//    implementation "io.springfox:springfox-boot-starter:3.0.0"
-//    implementation "io.springfox:springfox-swagger-ui:3.0.0"
+    // lombok
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // swagger
     implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
-//    implementation 'org.springdoc:springdoc-openapi-webmvc-core:1.7.0'
 
     // spring security
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -53,6 +55,8 @@ dependencies {
 
     // firebase - fcm
     implementation 'com.google.firebase:firebase-admin:9.1.1'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dodal/meet/configuration/SecurityConfig.java
+++ b/src/main/java/com/dodal/meet/configuration/SecurityConfig.java
@@ -37,7 +37,8 @@ public class SecurityConfig {
     public SecurityFilterChain resources(HttpSecurity http) throws Exception {
         return http.csrf().disable().
                 requestMatchers(matchers-> matchers.antMatchers("/v3/api-docs/**", "/v3/api-docs.yaml", "/swagger*/**",
-                        "/api/**/users/sign-in", "/api/**/users/sign-up", "/api/**/users/nickname", "/api/**/users/profile"))
+                        "/api/**/users/sign-in", "/api/**/users/sign-up", "/api/**/users/nickname", "/api/**/users/profile",
+                        "/api/**/categories/tags"))
                 .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
                 .requestCache(RequestCacheConfigurer::disable)
                 .securityContext(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/dodal/meet/controller/CategoryController.java
+++ b/src/main/java/com/dodal/meet/controller/CategoryController.java
@@ -1,0 +1,43 @@
+package com.dodal.meet.controller;
+
+import com.dodal.meet.controller.response.Response;
+import com.dodal.meet.controller.response.category.CategoryAndTagInfoResponse;
+import com.dodal.meet.service.CategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.Link;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@Tag(name = "Category", description = "카테고리 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+@Slf4j
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @Operation(summary = "카테고리와 하위 태그 전체 조회 API"
+            , description = "카테고리 정보와 카테고리에 해당하는 태그 정보를 반환한다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "성공", useReturnTypeSchema = true),
+                    @ApiResponse(responseCode = "500", description = "실패 - NOT_FOUND_TAG", content = @Content(schema = @Schema(implementation = Response.class)))
+            })
+    @GetMapping("/categories/tags")
+    public ResponseEntity<EntityModel<Response<CategoryAndTagInfoResponse>>> getCategoryAndTags() {
+        Link selfRel = linkTo(methodOn(CategoryController.class).getCategoryAndTags()).withSelfRel();
+        return new ResponseEntity<>(EntityModel.of(Response.success(categoryService.getCategoryAndTags()), selfRel), HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/dodal/meet/controller/UserController.java
+++ b/src/main/java/com/dodal/meet/controller/UserController.java
@@ -148,7 +148,8 @@ public class UserController {
         return new ResponseEntity<>(EntityModel.of(Response.success(), selfRel), HttpStatus.NO_CONTENT) ;
     }
 
-    private Link getSignInLink() {
+    public Link getSignInLink() {
         return linkTo(methodOn(UserController.class).signIn(null)).withRel("sign-in");
     }
+
 }

--- a/src/main/java/com/dodal/meet/controller/request/user/UserSignInRequest.java
+++ b/src/main/java/com/dodal/meet/controller/request/user/UserSignInRequest.java
@@ -5,13 +5,14 @@ import com.dodal.meet.model.SocialType;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
 @Schema(description = "유저 소셜 로그인 요청")
 @JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserSignInRequest {
     @Schema(description = "소셜 타입", allowableValues = {"KAKAO", "GOOGLE", "APPLE"}, example = "KAKAO")
     private SocialType socialType;

--- a/src/main/java/com/dodal/meet/controller/request/user/UserSignUpRequest.java
+++ b/src/main/java/com/dodal/meet/controller/request/user/UserSignUpRequest.java
@@ -4,13 +4,15 @@ import com.dodal.meet.model.SocialType;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
+
 import java.util.List;
 @Getter
 @Schema(description = "유저 소셜 회원가입 요청")
 @JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserSignUpRequest {
 
     @Schema(description = "소셜 타입", allowableValues = {"KAKAO", "GOOGLE", "APPLE"}, example = "KAKAO")
@@ -32,5 +34,5 @@ public class UserSignUpRequest {
     private String content;
 
     @Schema(description = "관심 카테고리", example = "[\"001001\", \"002003\", \"004001\" ]")
-    private List<Integer> favoriteCategory;
+    private List<String> tagList;
 }

--- a/src/main/java/com/dodal/meet/controller/response/category/CategoryAndTagInfoResponse.java
+++ b/src/main/java/com/dodal/meet/controller/response/category/CategoryAndTagInfoResponse.java
@@ -1,0 +1,21 @@
+package com.dodal.meet.controller.response.category;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import java.util.List;
+
+@Builder
+@Getter
+@Setter
+@Schema(description = "카테고리와 태그 정보 응답")
+@JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class CategoryAndTagInfoResponse {
+
+    @Schema(description = "카테고리 / 하위 태그 정보")
+    private List<CategoryResponse> categories;
+
+}

--- a/src/main/java/com/dodal/meet/controller/response/category/CategoryResponse.java
+++ b/src/main/java/com/dodal/meet/controller/response/category/CategoryResponse.java
@@ -1,0 +1,31 @@
+package com.dodal.meet.controller.response.category;
+
+import com.dodal.meet.model.entity.CategoryEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class CategoryResponse {
+
+    @Schema(description = "카테고리명", example = "건강")
+    private String name;
+
+    @Schema(description = "카테고리값", example = "001")
+    private String value;
+
+    @Schema(description = "태그정보", example = "체중 관리, 홈 트레이닝 등")
+    private List<TagResponse> tags;
+
+    public static CategoryResponse fromEntity(CategoryEntity entity) {
+        return CategoryResponse.builder()
+                .name(entity.getName())
+                .value(entity.getValue())
+                .tags(TagResponse.tagEntitiesToList(entity.getTagEntities()))
+                .build();
+    }
+}

--- a/src/main/java/com/dodal/meet/controller/response/category/TagResponse.java
+++ b/src/main/java/com/dodal/meet/controller/response/category/TagResponse.java
@@ -1,0 +1,46 @@
+package com.dodal.meet.controller.response.category;
+
+import com.dodal.meet.model.entity.TagEntity;
+import com.dodal.meet.model.entity.UserTagEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@Builder
+public class TagResponse {
+
+    @Schema(description = "태그명", example = "체중 관리")
+    private String name;
+
+    @Schema(description = "태그값", example = "001001")
+    private String value;
+
+    public static List<TagResponse> tagEntitiesToList(List<TagEntity> tagEntities) {
+        return tagEntities.stream().map(entity -> fromTagEntity(entity)).collect(Collectors.toList());
+    }
+
+    public static List<TagResponse> userEntitesToList(List<UserTagEntity> userTagEntities) {
+        return userTagEntities.stream().map(entity -> fromUserEntity(entity)).collect(Collectors.toList());
+    }
+
+    private static TagResponse fromTagEntity(TagEntity entity) {
+        return TagResponse.builder()
+                .name(entity.getName())
+                .value(entity.getValue())
+                .build();
+    }
+
+    private static TagResponse fromUserEntity(UserTagEntity entity) {
+        return TagResponse.builder()
+                .name(entity.getTagName())
+                .value(entity.getTagValue())
+                .build();
+    }
+}

--- a/src/main/java/com/dodal/meet/controller/response/user/UserInfoResponse.java
+++ b/src/main/java/com/dodal/meet/controller/response/user/UserInfoResponse.java
@@ -1,5 +1,6 @@
 package com.dodal.meet.controller.response.user;
 
+import com.dodal.meet.controller.response.category.TagResponse;
 import com.dodal.meet.model.SocialType;
 import com.dodal.meet.model.UserRole;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
@@ -9,6 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.sql.Timestamp;
+import java.util.List;
 
 @Builder
 @Getter
@@ -38,6 +40,9 @@ public class UserInfoResponse {
 
     @Schema(description = "유저 한 줄 소개", example = "안녕하세요")
     private String content;
+
+    @Schema(description = "관심 있는 태그 정보")
+    private List<TagResponse> tagList;
 
     @Schema(description = "알람 허용 여부", example = "Y", allowableValues = {"Y", "N"})
     private char alarmYn;

--- a/src/main/java/com/dodal/meet/exception/ErrorCode.java
+++ b/src/main/java/com/dodal/meet/exception/ErrorCode.java
@@ -21,7 +21,9 @@ public enum ErrorCode {
 
     // 500 - INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
-    NOT_FOUND_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 정보는 있으나, 토큰 정보가 없습니다.")
+    NOT_FOUND_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 정보는 있으나, 토큰 정보가 없습니다."),
+
+    NOT_FOUND_TAG(HttpStatus.INTERNAL_SERVER_ERROR, "태그 정보가 서버에 존재하지 않습니다.")
     ;
 
 

--- a/src/main/java/com/dodal/meet/model/entity/CategoryEntity.java
+++ b/src/main/java/com/dodal/meet/model/entity/CategoryEntity.java
@@ -1,0 +1,32 @@
+package com.dodal.meet.model.entity;
+
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "category")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
+@AllArgsConstructor
+@Builder
+public class CategoryEntity {
+
+    @Id
+    @Column(name = "category_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @OneToMany(mappedBy = "categoryEntity", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TagEntity> tagEntities = new ArrayList<>();
+    private String name;
+
+    private String value;
+
+}

--- a/src/main/java/com/dodal/meet/model/entity/TagEntity.java
+++ b/src/main/java/com/dodal/meet/model/entity/TagEntity.java
@@ -1,0 +1,31 @@
+package com.dodal.meet.model.entity;
+
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "tag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
+@AllArgsConstructor
+@Builder
+public class TagEntity {
+
+    @Id
+    @Column(name = "tag_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private CategoryEntity categoryEntity;
+
+    private String name;
+
+    private String value;
+}

--- a/src/main/java/com/dodal/meet/model/entity/UserEntity.java
+++ b/src/main/java/com/dodal/meet/model/entity/UserEntity.java
@@ -7,11 +7,7 @@ import com.dodal.meet.model.UserRole;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 import org.springframework.util.Assert;
-
 import javax.persistence.*;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -19,8 +15,6 @@ import java.time.Instant;
 @Entity
 @Table(name = "user")
 @Getter
-//@SQLDelete(sql = "UPDATE user SET deleted_at = NOW() where user_id = ?")
-//@Where(clause = "deleted_at is NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
 public class UserEntity {

--- a/src/main/java/com/dodal/meet/model/entity/UserTagEntity.java
+++ b/src/main/java/com/dodal/meet/model/entity/UserTagEntity.java
@@ -1,0 +1,39 @@
+package com.dodal.meet.model.entity;
+
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+import javax.persistence.*;
+
+@Entity
+@Table(name = "user_tag")
+@Getter
+@JsonNaming(value = PropertyNamingStrategy.SnakeCaseStrategy.class)
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserTagEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_tag_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "user_id")
+    private UserEntity userEntity;
+
+    private String tagName;
+
+    private String tagValue;
+
+    public static UserTagEntity tagEntityToUserTagEntity(UserEntity userEntity, TagEntity tagEntity) {
+        return UserTagEntity.builder()
+                .userEntity(userEntity)
+                .tagName(tagEntity.getName())
+                .tagValue(tagEntity.getValue())
+                .build();
+    }
+
+}

--- a/src/main/java/com/dodal/meet/repository/CategoryEntityRepository.java
+++ b/src/main/java/com/dodal/meet/repository/CategoryEntityRepository.java
@@ -1,0 +1,12 @@
+package com.dodal.meet.repository;
+
+import com.dodal.meet.model.entity.CategoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface CategoryEntityRepository extends JpaRepository<CategoryEntity, Integer> {
+
+    List<CategoryEntity> findAllByOrderByIdAsc();
+}

--- a/src/main/java/com/dodal/meet/repository/TagEntityRepository.java
+++ b/src/main/java/com/dodal/meet/repository/TagEntityRepository.java
@@ -1,0 +1,11 @@
+package com.dodal.meet.repository;
+
+import com.dodal.meet.model.entity.TagEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+@Repository
+public interface TagEntityRepository extends JpaRepository<TagEntity, Integer> {
+    Optional<TagEntity> findByValue(String value);
+}

--- a/src/main/java/com/dodal/meet/repository/UserTagEntityRepository.java
+++ b/src/main/java/com/dodal/meet/repository/UserTagEntityRepository.java
@@ -1,0 +1,12 @@
+package com.dodal.meet.repository;
+
+import com.dodal.meet.model.entity.UserEntity;
+import com.dodal.meet.model.entity.UserTagEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface UserTagEntityRepository extends JpaRepository<UserTagEntity, Long> {
+    List<UserTagEntity> findAllByUserEntity(UserEntity entity);
+}

--- a/src/main/java/com/dodal/meet/service/CategoryService.java
+++ b/src/main/java/com/dodal/meet/service/CategoryService.java
@@ -1,0 +1,37 @@
+package com.dodal.meet.service;
+
+import com.dodal.meet.controller.response.category.CategoryAndTagInfoResponse;
+import com.dodal.meet.controller.response.category.CategoryResponse;
+import com.dodal.meet.exception.DodalApplicationException;
+import com.dodal.meet.exception.ErrorCode;
+import com.dodal.meet.model.entity.CategoryEntity;
+import com.dodal.meet.repository.CategoryEntityRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryEntityRepository categoryEntityRepository;
+
+    @Transactional(readOnly = true)
+    public CategoryAndTagInfoResponse getCategoryAndTags() {
+        List<CategoryEntity> categoryEntities = categoryEntityRepository.findAllByOrderByIdAsc();
+        if (categoryEntities == null) {
+            throw new DodalApplicationException(ErrorCode.NOT_FOUND_TAG);
+        }
+        List<CategoryResponse> categoryResponses = categoryEntities.stream()
+                        .map(CategoryResponse::fromEntity).collect(Collectors.toList());
+
+        return CategoryAndTagInfoResponse
+                .builder()
+                .categories(categoryResponses)
+                .build();
+    }
+}

--- a/src/main/java/com/dodal/meet/service/ImageService.java
+++ b/src/main/java/com/dodal/meet/service/ImageService.java
@@ -52,16 +52,6 @@ public class ImageService {
             amazonS3Client.putObject(bucket, uniqueFileName, multipartFile.getInputStream(), objectMetadata);
 
             final String s3ImageUrl = amazonS3Client.getUrl(bucket, uniqueFileName).toString();
-            /*
-            User user = UserUtils.getUserInfo(authentication);
-            if (user != null) {
-                UserEntity entity = userEntityRepository.findBySocialIdAndSocialType(user.getSocialId(), user.getSocialType())
-                        .orElseThrow(() -> new DodalApplicationException(ErrorCode.INVALID_USER_REQUEST));
-                entity.updateProfileUrl(s3ImageUrl);
-
-                userEntityRepository.save(entity);
-            }
-             */
             response.setProfileUrl(s3ImageUrl);
         } catch (IOException e) {
             log.error(e.getMessage());

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,9 +13,15 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
+    defer-datasource-initialization: true
     properties:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
     open-in-view: false
+  sql:
+    init:
+      mode: always
+      encoding: utf-8
+      platform: mysql

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,81 @@
+INSERT INTO category (name, value)
+SELECT
+    name, value
+FROM
+(
+    SELECT '건강' as name, '001' as value FROM DUAL UNION ALL
+    SELECT '스터디' as name, '002' as value FROM DUAL UNION ALL
+    SELECT '루틴' as name, '003' as value FROM DUAL UNION ALL
+    SELECT '취미' as name, '004' as value FROM DUAL UNION ALL
+    SELECT '기타' as name, '005' as value FROM DUAL
+) A
+WHERE NOT EXISTS (SELECT 1 FROM category)
+;
+
+INSERT INTO tag (category_id, name, value)
+SELECT
+    category_id, name, value
+FROM
+    (
+        SELECT (SELECT category_id from category where value = '001') as category_id, '체중 관리' as name, '001001' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '001') as category_id, '홈 트레이닝' as name, '001002' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '001') as category_id, '식단 관리/식습관' as name, '001003' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '001') as category_id, '피트니스 센터' as name, '001004' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '001') as category_id, '야외 활동' as name, '001005' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '001') as category_id, '마음 챙기기' as name, '001006' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '001') as category_id, '기타' as name, '001007' as value FROM DUAL
+    ) A
+WHERE NOT EXISTS (SELECT 1 FROM tag where category_id = (SELECT category_id from category where value = '001'))
+;
+
+INSERT INTO tag (category_id, name, value)
+SELECT
+    category_id, name, value
+FROM
+    (
+        SELECT (SELECT category_id from category where value = '002') as category_id, '커리어' as name, '002001' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '002') as category_id, '자기개발' as name, '002002' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '002') as category_id, '지식 채우기' as name, '002003' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '002') as category_id, '자격증' as name, '002004' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '002') as category_id, '외국어' as name, '002005' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '002') as category_id, '기타' as name, '002006' as value FROM DUAL
+    ) A
+WHERE NOT EXISTS (SELECT 1 FROM tag where category_id = (SELECT category_id from category where value = '002'))
+;
+
+INSERT INTO tag (category_id, name, value)
+SELECT
+    category_id, name, value
+FROM
+    (
+        SELECT (SELECT category_id from category where value = '003') as category_id, '기상' as name, '003001' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '003') as category_id, '수면' as name, '003002' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '003') as category_id, '루틴' as name, '003003' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '003') as category_id, '시간관리/계획' as name, '003004' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '003') as category_id, '기타' as name, '003005' as value FROM DUAL
+    ) A
+WHERE NOT EXISTS (SELECT 1 FROM tag where category_id = (SELECT category_id from category where value = '003'))
+;
+
+INSERT INTO tag (category_id, name, value)
+SELECT
+    category_id, name, value
+FROM
+    (
+        SELECT (SELECT category_id from category where value = '004') as category_id, '음악/악기' as name, '004001' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '004') as category_id, '독서' as name, '004002' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '004') as category_id, '만들기/그리기' as name, '004003' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '004') as category_id, '전시/관람' as name, '004004' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '004') as category_id, '글쓰기' as name, '004005' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '004') as category_id, 'SNS 활동' as name, '004006' as value FROM DUAL UNION ALL
+        SELECT (SELECT category_id from category where value = '004') as category_id, '기타' as name, '004007' as value FROM DUAL
+    ) A
+WHERE NOT EXISTS (SELECT 1 FROM tag where category_id = (SELECT category_id from category where value = '004'))
+;
+
+INSERT INTO tag (category_id, name, value)
+SELECT
+    (SELECT category_id from category where value = '005') as category_id, '기타' as name, '005001'
+FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM tag where category_id = (SELECT category_id from category where value = '005'))
+;


### PR DESCRIPTION
- 테이블 생성 (category, tag, user_tag)
- 카테고리 / 태그 기본 데이터 생성 (data.sql) 
- 유저 로그인 시 (지정한 태그 db 저장)
- 유저 정보 조회 시 지정한 태그리스트 조회되도록 추가